### PR TITLE
feat: Add telegram notification

### DIFF
--- a/src/lib/Video.ts
+++ b/src/lib/Video.ts
@@ -23,6 +23,7 @@ import { updatePlex } from "./helpers/updatePlex.js";
 
 import { ProgressHeadless } from "./logging/ProgressConsole.js";
 import { ProgressBars } from "./logging/ProgressBars.js";
+import { notifyDownloaded, notifyError } from "./notifications/notify.js";
 
 const exec = promisify(execCallback);
 const sleep = promisify(setTimeout);
@@ -178,6 +179,7 @@ export class Video extends Attachment {
 				}
 				logger.done(chalk`{cyan Download & Muxing complete!}`);
 				promDownloadedTotal.inc();
+				notifyDownloaded(this);
 				break;
 			} catch (error) {
 				const message = this.parseErrorMessage(error);
@@ -188,6 +190,7 @@ export class Video extends Attachment {
 					await sleep(1000 * retries);
 				} else {
 					logger.error(`${message} - Failed`);
+					notifyError(this);
 				}
 			}
 		}

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -65,4 +65,11 @@ export const defaultSettings: Settings = {
 		prometheusExporterPort: null,
 		contributeMetrics: true,
 	},
+	notifications: {
+		telegram: {
+			enabled: false,
+			token: "",
+			chatId: "",
+		},
+	},
 };

--- a/src/lib/notifications/notify.ts
+++ b/src/lib/notifications/notify.ts
@@ -1,0 +1,19 @@
+import { settings } from "../helpers/index.js";
+import { Video } from "../Video.js";
+import telegramNotify from "./telegram.js";
+
+export const notifyDownloaded = (video: Video) => {
+	const { videoTitle, channelTitle } = video;
+	const message = `Downloaded ${videoTitle} from ${channelTitle}`;
+	if (settings.notifications.telegram && settings.notifications.telegram.enabled) {
+		telegramNotify(message);
+	}
+};
+
+export const notifyError = (video: Video) => {
+	const { videoTitle, channelTitle } = video;
+	const message = `Error downloading ${videoTitle} from ${channelTitle}`;
+	if (settings.notifications.telegram && settings.notifications.telegram.enabled) {
+		telegramNotify(message);
+	}
+};

--- a/src/lib/notifications/telegram.ts
+++ b/src/lib/notifications/telegram.ts
@@ -1,0 +1,20 @@
+import { settings } from "../helpers/index.js";
+
+export default async function telegramNotify(message: string) {
+	const telegram = settings.notifications.telegram;
+	if (!telegram || !telegram.enabled) return;
+	try {
+		fetch(`https://api.telegram.org/bot${telegram.token}/sendMessage`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				chat_id: telegram.chatId,
+				text: message,
+			}),
+		});
+	} catch {
+		console.error("Failed to send telegram notification");
+	}
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,14 @@ export interface Extras extends Record<string, boolean> {
 
 export type Resolution = ValueOfA<Resolutions>;
 
+export type Notification = {
+	telegram?: {
+		token: string;
+		chatId: string;
+		enabled: boolean;
+	};
+};
+
 export type Settings = {
 	__SettingsWiki: string;
 	runQuickstartPrompts: boolean;
@@ -68,4 +76,5 @@ export type Settings = {
 		prometheusExporterPort: number | null;
 		contributeMetrics: boolean;
 	};
+	notifications: Notification;
 };


### PR DESCRIPTION
I use Telegram to keep track of downloaded content (Sonarr, Radarr, etc...). I though it would be cool to have a notification system when Floatplane Downloaded add new content to my library at the same place.

Pretty basic notification system :
- Add notifications in Settings DB
- Add Telegram notify to send message to corresponding token and chat_id
- Can be extended to other services if needed
- Notify download and error

![image](https://github.com/user-attachments/assets/f4e5e1ed-ad99-4a0e-8100-cd0dca299686)

